### PR TITLE
powify logs fallback to development env, if RAILS_ENV isn't set 

### DIFF
--- a/lib/powify/app.rb
+++ b/lib/powify/app.rb
@@ -136,7 +136,7 @@ module Powify
       def logs(args = [])
         app_name = args[0] ? args[0].strip.to_s.downcase : File.basename(current_path)
         symlink_path = "#{POWPATH}/#{app_name}"
-        system "tail -f #{symlink_path}/log/#{ENV['RAILS_ENV']}.log"
+        system "tail -f #{symlink_path}/log/#{ENV['RAILS_ENV']||'development'}.log"
       end
     end
   end


### PR DESCRIPTION
Fixes powify logs "tail: ~/.pow/myapp/log/.log: No such file or directory". I think this is safe, because rails uses development as the fallback, if no RAILS_ENV is set.
