### PR TITLE
Prevent environment command from completely overwriting existing .powenv

### DIFF
--- a/lib/powify/app.rb
+++ b/lib/powify/app.rb
@@ -123,17 +123,15 @@ module Powify
         return if args.empty?
         app_name, env = File.basename(current_path), args[0].strip.to_s.downcase
         app_name, env = args[0].strip.to_s.downcase, args[1].strip.to_s.downcase if args.size > 1
-        symlink_path = "#{POWPATH}/#{app_name}/.powenv"
-        if File.exists?(symlink_path)
-          text = File.read(symlink_path).rstrip
-          if text =~ /^export RAILS_ENV=\S+\Z/
-            text = text.gsub /^export RAILS_ENV=(\S+)\Z/, "export RAILS_ENV=#{env}"
-            File.open(symlink_path, "w") { |f| f.puts text }
-          else
-            %x{echo export RAILS_ENV=#{env} >> #{symlink_path}}
-          end
+        env_file = "#{POWPATH}/#{app_name}/.powenv"
+        if File.exists?(env_file)
+          contents = File.readlines(env_file).reject do |line|
+            # Ignore empty lines and lines that define the environment.
+            line.strip.empty? || line.match(/^export RAILS_ENV=(.+)/)
+          end.compact << "export RAILS_ENV=#{env}"
+          File.open(env_file, "w") { |f| f.puts contents }
         else
-          %x{echo export RAILS_ENV=#{env} > #{symlink_path}}
+          %x{echo export RAILS_ENV=#{env} > #{env_file}}
         end
         $stdout.puts "Successfully changed environment to #{env}."
         restart [app_name]


### PR DESCRIPTION
Today, "powify development production" completely overwrites any existing .powenv file.  This pull request changes that, by...
1. Creating a new .powenv file if one doesn't already exist, or
2. If one _does_ exist, simply append a new "export RAILS_ENV=..." call to the end of the existing one.
3. Special case of (2): if the last (non-whitespace) line of the existing powenv is a call to set the environment, _replace_ the old environment with the new one, rather than appending yet another call.
