### PR TITLE
Add xip command to open app on xip.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ APP COMMANDS
   powify rename [OLD] [NEW]        rename the pow app [OLD] to [NEW]
   powify environment [ENV]         run the this pow app in a different environment (aliased `env`)
   powify browse [NAME]             opens and navigates the default browser to this app
+  powify xip [NAME]                opens and navigates the default browser to this app on xip.io
   powify logs [NAME]               tail the application logs
 ```
 

--- a/lib/powify/app.rb
+++ b/lib/powify/app.rb
@@ -1,7 +1,7 @@
 module Powify
   class App
     extend Powify
-    AVAILABLE_METHODS = %w(create link new destroy unlink remove restart always_restart always_restart_off browse open rename environment env logs)
+    AVAILABLE_METHODS = %w(create link new destroy unlink remove restart always_restart always_restart_off browse open rename environment env logs xip)
 
     class << self
       def run(args)
@@ -106,6 +106,26 @@ module Powify
         end
       end
       alias_method :open, :browse
+
+      # powify browse
+      # powify browse foo
+      # powify browse foo test
+      def xip(args = [])
+        app_name = args[0] ? args[0].strip.to_s.downcase : File.basename(current_path)
+        ext = args[1] || extension
+        symlink_path = "#{POWPATH}/#{app_name}"
+        if File.exists?(symlink_path)
+          local_ip = UDPSocket.open do |s|
+            s.connect('www.example.com', 1)
+            s.addr.last
+          end
+          url = "#{app_name}.#{local_ip}.xip.io"
+          %x{open http://#{url}}
+        else
+          $stdout.puts "Powify could not find an app to browse with the name #{app_name}"
+          Powify::Server.list
+        end
+      end
 
       # powify rename bar
       # powify rename foo bar


### PR DESCRIPTION
xip.io is a service that forwards requests to the local IP address
specified in the domain. So requests to
http://your-pow-app.your-local-ip.xip.io will open your POW app,
assuming the computer accessing the URL has access to your local IP.
This allows one to, for instance, test a POW app from a mobile device
on the same local network.

The new command functions just like `powify browse` except that it
adds the local ip address and the xip.io extension to the URL.
