### PR TITLE
Prevent error when command does not exist

### DIFF
--- a/lib/powify/client.rb
+++ b/lib/powify/client.rb
@@ -14,7 +14,8 @@ module Powify
           $stdout.puts e
         end
 
-        self.send (%w(version help) & args).first.to_sym
+        primary_arg = (%w(version help) & args).first
+        self.send primary_arg.to_sym if primary_arg
       end
 
       def version


### PR DESCRIPTION
Right now, if you misspell a command, powify will return something like:

```
The command `foo` does not exist!
powify/lib/powify/client.rb:19:in `run': undefined method `to_sym' for nil:NilClass (NoMethodError)
```

However, it could just say that the command does not exit, without failing over it.
