### PR TITLE
update in server restart method

### DIFF
--- a/lib/powify/server.rb
+++ b/lib/powify/server.rb
@@ -49,7 +49,8 @@ module Powify
 
       # Restart the POW server
       def restart
-        stop && start
+        stop
+        start
       end
 
       # Add POW domains to the hosts file


### PR DESCRIPTION
The command `powify server restart` seems to only stop the server. 

Updating the restart method so that the restart works.
